### PR TITLE
fixes `XCTest` import bug

### DIFF
--- a/Sources/Beet/Beets/String.swift
+++ b/Sources/Beet/Beets/String.swift
@@ -1,5 +1,4 @@
 import Foundation
-import XCTest
 
 /**
  * De/Serializes a UTF8 string of a particular size.


### PR DESCRIPTION
Currently the source code is attempting to import XCTest. Removing this import alleviated the build failure caused by this line.