### PR TITLE
Replace fixedSizeMap with fixedSizeHashMap

### DIFF
--- a/Sources/Beet/Beets/Maps.swift
+++ b/Sources/Beet/Beets/Maps.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct fixedSizeMap: ElementCollectionFixedSizeBeet {
+public class fixedSizeHashMap: ElementCollectionFixedSizeBeet {
    
     public let keyElement: Beet
     public let valElement: Beet
@@ -164,9 +164,14 @@ public struct fixedSizeMap: ElementCollectionFixedSizeBeet {
     }
 }
 
-public struct map: FixableBeet {
+public class hashmap: FixableBeet {
     public let keyElement: Beet
     public let valElement: Beet
+    
+    public init(keyElement: Beet, valElement: Beet) {
+        self.keyElement = keyElement
+        self.valElement = valElement
+    }
     
     private var keyIsFixed: Bool {
         return isFixedSizeBeet(x: keyElement)
@@ -183,7 +188,7 @@ public struct map: FixableBeet {
         if (keyIsFixed && valIsFixed) {
             return FixedSizeBeet(
                 value: FixedSizeBeetType.collection(
-                    fixedSizeMap(keyElement: keyElement, valElement: valElement, fixedElements: [:], len: len)
+                    fixedSizeHashMap(keyElement: keyElement, valElement: valElement, fixedElements: [:], len: len)
                 )
             )
         }
@@ -214,7 +219,7 @@ public struct map: FixableBeet {
         }
         return FixedSizeBeet(
             value: FixedSizeBeetType.collection(
-                fixedSizeMap(keyElement: keyElement, valElement: valElement, fixedElements: fixedBeets, len: len)
+                fixedSizeHashMap(keyElement: keyElement, valElement: valElement, fixedElements: fixedBeets, len: len)
             )
         )
     }
@@ -225,7 +230,7 @@ public struct map: FixableBeet {
         if (keyIsFixed && valIsFixed) {
             return FixedSizeBeet(
                 value: FixedSizeBeetType.collection(
-                    fixedSizeMap(
+                    fixedSizeHashMap(
                         keyElement: keyElement, valElement: valElement, fixedElements: [:], len: UInt32(len)
                     )
                 )
@@ -253,7 +258,7 @@ public struct map: FixableBeet {
         }
         return FixedSizeBeet(
             value: FixedSizeBeetType.collection(
-                fixedSizeMap(keyElement: keyElement, valElement: valElement, fixedElements: fixedBeets, len: UInt32(len))
+                fixedSizeHashMap(keyElement: keyElement, valElement: valElement, fixedElements: fixedBeets, len: UInt32(len))
             )
         )
     }

--- a/Tests/BeetTests/unit/Map.swift
+++ b/Tests/BeetTests/unit/Map.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class mapTests: XCTestCase {
     func testCompatMapsTopLevelHMapU8U8() {
-        let beet = map(keyElement: .fixedBeet(.init(value: .scalar(u8()))),
+        let beet = hashmap(keyElement: .fixedBeet(.init(value: .scalar(u8()))),
                        valElement: .fixedBeet(.init(value: .scalar(u8())))
         )
         
@@ -35,7 +35,7 @@ final class mapTests: XCTestCase {
     }
     
     func testCompatMapsTopLevelBTreeMapU8U8(){
-        let beet = map(keyElement: .fixedBeet(.init(value: .scalar(u8()))),
+        let beet = hashmap(keyElement: .fixedBeet(.init(value: .scalar(u8()))),
                        valElement: .fixedBeet(.init(value: .scalar(u8())))
         )
         let fixtures = stubbedResponse("maps")
@@ -61,7 +61,7 @@ final class mapTests: XCTestCase {
         }
     }
     func testCompatMapsTopLevelHashMapStringI32(){
-        let beet = map(keyElement: .fixableBeat(Utf8String()),
+        let beet = hashmap(keyElement: .fixableBeat(Utf8String()),
                        valElement: .fixedBeet(.init(value: .scalar(i32())))
         )
         let fixtures = stubbedResponse("maps")
@@ -87,7 +87,7 @@ final class mapTests: XCTestCase {
     }
     
     func testCompatMapsTopLevelHashMapStringArrayI8(){
-        let beet = map(keyElement: .fixableBeat(Utf8String()),
+        let beet = hashmap(keyElement: .fixableBeat(Utf8String()),
                        valElement: .fixableBeat(array(element: .fixedBeet(.init(value: .scalar(i8())))))
         )
         let fixtures = stubbedResponse("maps")
@@ -116,7 +116,7 @@ final class mapTests: XCTestCase {
         // NOTE: this checks deserialization only as it turned out complex enough
         // already to set up this test
         let beet = array(element: .fixableBeat(
-                            map(keyElement: .fixableBeat(Utf8String()),
+                            hashmap(keyElement: .fixableBeat(Utf8String()),
                                 valElement: .fixedBeet(.init(value: .scalar(i64())))
                             )
                         )


### PR DESCRIPTION
- Replace `fixedSizeMap` struct with `fixedSizeHashMap` class
- Add `init` method to `hashmap` class
- Make `map` and `fixedSizeMap` conform to `FixableBeet` protocol
- Replace `map` with `hashmap` for top level Beet maps, BTree maps, Hash maps, and Beet arrays of Hash maps

[Sources/Beet/Beets/Maps.swift]
- Replace `fixedSizeMap` struct with `fixedSizeHashMap` class
- Add `init` method to `hashmap` class
- Make `map` and `fixedSizeMap` conform to `FixableBeet` protocol
- Add `len` parameter to `fixedSizeHashMap` class
- Change type of `len` parameter from `UInt32` to `Int` in `map` and `fixedSizeMap` [Tests/BeetTests/unit/map.swift]
- Replace `map` with `hashmap` for top level Beet maps
- Replace `map` with `hashmap` for top level BTree maps
- Replace `map` with `hashmap` for top level Hash maps
- Replace `map` with `hashmap` for top level Beet arrays of Hash maps