### PR TITLE
Update Maps.swift for hashmap type

### DIFF
--- a/Sources/Beet/Beets/Maps.swift
+++ b/Sources/Beet/Beets/Maps.swift
@@ -269,11 +269,11 @@ public class hashmap: FixableBeet {
 }
 
 public enum MapsTypeMapKey: String {
-    case map
+    case hashmap
 }
 
 public typealias MapsTypeMap = (MapsTypeMapKey, SupportedTypeDefinition)
 
 public let mapsTypeMap: [MapsTypeMap] = [
-    (MapsTypeMapKey.map, SupportedTypeDefinition(beet: "map(keyElement: {{innerK}}, valElement: {{innerV}})", isFixable: true, sourcePack: BEET_PACKAGE, swift: "Dictionary"))
+    (MapsTypeMapKey.hashmap, SupportedTypeDefinition(beet: "hashmap(keyElement: {{innerK}}, valElement: {{innerV}})", isFixable: true, sourcePack: BEET_PACKAGE, swift: "Dictionary"))
 ]


### PR DESCRIPTION
- Update the map type key from `map` to `hashmap`
- Include `hashmap` type in the `mapsTypeMap`

[Sources/Beet/Beets/Maps.swift]
- Change the map type key from `map` to `hashmap`
- Update the `mapsTypeMap` to include `hashmap` type